### PR TITLE
Export pricing

### DIFF
--- a/src/query-jobs/campaign_metadata.js
+++ b/src/query-jobs/campaign_metadata.js
@@ -12,7 +12,11 @@ export default async function job(config) {
       name,
       type,
       created_at,
-      updated_at
+      updated_at,
+      external_id,
+      budget_model,
+      budget_cents,
+      budget_currency
     FROM ${process.env.BIGQUERY_DATASET}.campaigns
     WHERE id IN (
       SELECT DISTINCT campaign_id FROM ${process.env.BIGQUERY_DATASET}.flights

--- a/src/query-jobs/flight_metadata.js
+++ b/src/query-jobs/flight_metadata.js
@@ -25,7 +25,11 @@ export default async function job(config) {
       unique_per_campaign,
       unique_per_advertiser,
       created_at,
-      updated_at
+      updated_at,
+      external_id,
+      price_model,
+      price_cents,
+      price_currency
     FROM ${process.env.BIGQUERY_DATASET}.flights
     WHERE podcast_id IN (${config.podcastIds.join(", ")})
   `;


### PR DESCRIPTION
Export some of the more recently added BQ fields.

I added `external_id` on flights/campaigns, but omitted `integration_id`.  Just because we don't sync the `integrations` table to BQ, so not much point giving that ID to 3rd parties.