### PR TITLE
Boostr collection external ids

### DIFF
--- a/src/query-jobs/boostr_impressions.js
+++ b/src/query-jobs/boostr_impressions.js
@@ -6,16 +6,17 @@
 export default async function job(config) {
   const query = `
     SELECT
-      FORMAT_TIMESTAMP("%m/%d/%Y", timestamp) AS Date,
-      external_id AS \`Ad Server Line\`,
-      count(*) AS Impressions
-    FROM ${process.env.BIGQUERY_DATASET}.dt_impressions
-    INNER JOIN ${process.env.BIGQUERY_DATASET}.flights ON (flight_id = id)
-    WHERE timestamp >= ?
-      AND timestamp < ?
-      AND is_duplicate = false
-      AND creative_id IS NOT NULL
-      AND integration_id IN (${config.integrationIds.join(", ")})
+      FORMAT_TIMESTAMP("%m/%d/%Y", i.timestamp) AS Date,
+      COALESCE(x.external_id, f.external_id) AS \`Ad Server Line\`,
+      COUNT(*) AS Impressions
+    FROM ${process.env.BIGQUERY_DATASET}.dt_impressions i
+    INNER JOIN ${process.env.BIGQUERY_DATASET}.flights f ON (i.flight_id = f.id)
+    LEFT JOIN ${process.env.BIGQUERY_DATASET}.flight_collection_external_ids x ON (f.id = x.flight_id AND i.feeder_podcast = x.podcast_id)
+    WHERE i.timestamp >= ?
+      AND i.timestamp < ?
+      AND i.is_duplicate = FALSE
+      AND i.creative_id IS NOT NULL
+      AND f.integration_id IN (${config.integrationIds.join(", ")})
     GROUP BY Date, \`Ad Server Line\`
     ORDER BY Date ASC, \`Ad Server Line\` ASC
   `;


### PR DESCRIPTION
There's a new table `flight_collection_external_ids`, which maps podcast_ids within a collection back to the originating line_item.

Join that table, to get the correct lines for collection flights.